### PR TITLE
Bump snappy-java version to support Apple silicon

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                                     :password :env/clojars_password
                                     :sign-releases true}]]
   :dependencies [[byte-streams "0.2.0"]
-                 [org.xerial.snappy/snappy-java "1.1.1.7"]
+                 [org.xerial.snappy/snappy-java "1.1.8.3"]
                  [commons-codec/commons-codec "1.10"]
                  [net.jpountz.lz4/lz4 "1.3"]
                  [org.apache.commons/commons-compress "1.20"]]


### PR DESCRIPTION
To fix issue
https://github.com/clj-commons/byte-transforms/issues/8

bum snappy-java to a compatible version
https://github.com/xerial/snappy-java/releases/tag/1.1.8.2
