### PR TITLE
Upgrade the snappy-java version to 1.1.10.7

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                                     :password :env/clojars_password
                                     :sign-releases true}]]
   :dependencies [[byte-streams "0.2.0"]
-                 [org.xerial.snappy/snappy-java "1.1.8.4"]
+                 [org.xerial.snappy/snappy-java "1.1.10.7"]
                  [commons-codec/commons-codec "1.10"]
                  [net.jpountz.lz4/lz4 "1.3"]
                  [org.apache.commons/commons-compress "1.20"]]


### PR DESCRIPTION
fixes #12 

java-snappy version is been upgraded to 1.1.10.7

https://github.com/xerial/snappy-java/releases/tag/v1.1.10.7